### PR TITLE
page objects refactor to not load other page objects

### DIFF
--- a/pages/cart.py
+++ b/pages/cart.py
@@ -1,7 +1,3 @@
-import pages.checkout_1
-import pages.inventory
-
-
 class CartPage():
     def __init__(self, page):
         self.page = page
@@ -15,12 +11,9 @@ class CartPage():
 
     def click_continue_shopping(self):
         self.CONTINUE_SHOPPING_BUTTON.click()
-        return pages.inventory.InventoryPage(self.page)
 
     def click_checkout(self):
         self.CHECKOUT_BUTTON.click()
-        return pages.checkout_1.Checkout1Page(self.page)
 
     def get_shopping_cart_badge_value(self):
         return self.SHOPPING_CART_BADGE.text_content()
-

--- a/pages/checkout_1.py
+++ b/pages/checkout_1.py
@@ -1,5 +1,4 @@
 from utils import users
-import pages.checkout_2
 
 
 class Checkout1Page():
@@ -29,7 +28,6 @@ class Checkout1Page():
 
     def click_continue(self):
         self.CONTINUE_CHECKOUT_BUTTON.click()
-        return pages.checkout_2.Checkout2Page(self.page)
 
     def click_cancel(self):
         self.CANCEL_BUTTON.click()

--- a/pages/checkout_complete.py
+++ b/pages/checkout_complete.py
@@ -1,6 +1,3 @@
-import pages.inventory
-
-
 class CheckoutCompletePage():
     def __init__(self, page):
         self.page = page
@@ -10,4 +7,3 @@ class CheckoutCompletePage():
 
     def click_back_home_button(self):
         self.BACK_HOME_BUTTON.click()
-        return pages.inventory.InventoryPage(self.page)

--- a/pages/inventory.py
+++ b/pages/inventory.py
@@ -1,6 +1,3 @@
-import pages.cart
-
-
 class InventoryPage():
     def __init__(self, page):
         self.page = page
@@ -20,5 +17,3 @@ class InventoryPage():
 
     def click_view_cart(self):
         self.CART.click()
-        return pages.cart.CartPage(self.page)
-

--- a/pages/login.py
+++ b/pages/login.py
@@ -1,5 +1,4 @@
 from utils import users
-import pages.inventory
 
 
 class LoginPage():
@@ -31,7 +30,6 @@ class LoginPage():
 
     def login_valid_user(self, user):
         self.login(user)
-        return pages.inventory.InventoryPage(self.page)
 
     def login_with_invalid_user(self, user):
         self.login(user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 certifi==2022.12.7
 charset-normalizer==3.1.0
 exceptiongroup==1.1.1
+execnet==1.9.0
 greenlet==2.0.1
 idna==3.4
 importlib-metadata==6.6.0
@@ -12,6 +13,7 @@ pyee==9.0.4
 pytest==7.3.1
 pytest-base-url==2.0.0
 pytest-playwright==0.3.3
+pytest-xdist==3.3.1
 python-slugify==8.0.1
 requests==2.30.0
 text-unidecode==1.3

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -3,6 +3,7 @@ import re
 from playwright.sync_api import Page, expect
 from pages.login import LoginPage
 from pages.inventory import InventoryPage
+from pages.cart import CartPage
 
 @pytest.fixture(scope="function", autouse=True)
 def before_each_after_each(page: Page):
@@ -16,14 +17,17 @@ def before_each_after_each(page: Page):
 
 def test_url(page: Page):
     inventory_page = InventoryPage(page)
-    cart_page = inventory_page.click_view_cart()
+    inventory_page.click_view_cart()
+
+    cart_page = CartPage(page)
     expect(cart_page.page).to_have_url(re.compile(cart_page.get_expected_url()))
 
 def test_cart_badge_2_items(page: Page):
     inventory_page = InventoryPage(page)
     inventory_page.add_cart_bike_light()
     inventory_page.add_cart_backpack()
+    inventory_page.click_view_cart()
 
-    cart_page = inventory_page.click_view_cart()
+    cart_page = CartPage(page)
     cart_item_count = cart_page.get_shopping_cart_badge_value()
     assert cart_item_count == "2", "Shopping cart badge value incorrect."

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -3,6 +3,10 @@ import re
 from playwright.sync_api import Page, expect
 from pages.login import LoginPage
 from pages.inventory import InventoryPage
+from pages.cart import CartPage
+from pages.checkout_1 import Checkout1Page
+from pages.checkout_2 import Checkout2Page
+from pages.checkout_complete import CheckoutCompletePage
 
 @pytest.fixture(scope="function", autouse=True)
 def before_each_after_each(page: Page):
@@ -19,40 +23,44 @@ def test_checkout_scenario_single_item(page: Page):
     expect(inventory_page.page).to_have_url(re.compile(".*inventory"))
 
     inventory_page.add_cart_bike_light()
-    cart_page = inventory_page.click_view_cart()
+    inventory_page.click_view_cart()
 
-    checkout_1_page = cart_page.click_checkout()
+    cart_page = CartPage(page)
+    cart_page.click_checkout()
+
+    checkout_1_page = Checkout1Page(page)
     expect(checkout_1_page.page).to_have_url(re.compile(".*checkout-step-one"))
-
     checkout_1_page.fill_checkout_info("john")
+    checkout_1_page.click_continue()
 
-    checkout_2_page = checkout_1_page.click_continue()
+    checkout_2_page = Checkout2Page(page)
     expect(checkout_2_page.page).to_have_url(re.compile(".*checkout-step-two"))
+    checkout_2_page.click_finish_button()
 
-    checkout_complete_page = checkout_2_page.click_finish_button()
+    checkout_complete_page = CheckoutCompletePage(page)
     expect(checkout_complete_page.page).to_have_url(re.compile(".*checkout-complete"))
-
     expect(checkout_complete_page.COMPLETE_HEADER).to_contain_text('Thank you for your order!')
 
 
 def test_checkout_scenario_continue_shopping(page: Page):
     inventory_page = InventoryPage(page)
     inventory_page.add_cart_bike_light()
+    inventory_page.click_view_cart()
 
-    cart_page = inventory_page.click_view_cart()
-
-    inventory_page = cart_page.click_continue_shopping()
+    cart_page = CartPage(page)
+    cart_page.click_continue_shopping()
 
     inventory_page.add_cart_backpack()
+    inventory_page.click_view_cart()
 
-    cart_page = inventory_page.click_view_cart()
+    cart_page.click_checkout()
 
-    checkout_1_page = cart_page.click_checkout()
-
+    checkout_1_page = Checkout1Page(page)
     checkout_1_page.fill_checkout_info("mary")
+    checkout_1_page.click_continue()
 
-    checkout_2_page = checkout_1_page.click_continue()
+    checkout_2_page = Checkout2Page(page)
+    checkout_2_page.click_finish_button()
 
-    checkout_complete_page = checkout_2_page.click_finish_button()
-
+    checkout_complete_page = CheckoutCompletePage(page)
     expect(checkout_complete_page.COMPLETE_HEADER).to_contain_text('Thank you for your order!')

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -2,6 +2,7 @@ import pytest
 import re
 from playwright.sync_api import Page, expect
 from pages.login import LoginPage
+from pages.inventory import InventoryPage
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -20,7 +21,8 @@ def test_pageload(page: Page):
 
 def test_valid_user(page: Page):
     login_page = LoginPage(page)
-    inventory_page = login_page.login_valid_user("standard_user")
+    login_page.login_valid_user("standard_user")
+    inventory_page = InventoryPage(page)
     expect(inventory_page.page).to_have_url(re.compile(inventory_page.get_expected_url()))
 
 def test_invalid_user(page: Page):


### PR DESCRIPTION
- refactor page objects and tests to eliminate the chance of circular dependencies by not loading other page object in a page object class.
- add package `pytest-xdist` to allow simultaneous tests to be run if running on multi-core machine.  